### PR TITLE
Isolate Prod Environment with Docker

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,16 @@
+FROM node:20-alpine3.20 AS build
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN npm i && \
+  npm run build
+
+FROM nginx:alpine3.19-slim
+
+COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
+
+COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Olá! Sou **Edson Pimenta**, um **desenvolvedor full-stack** em constante evolu�
 Com foco na **entrega de conteúdo útil e performático**, optei pelas seguintes tecnologias:
 
 - _Astro_;
-- _TypeScript_.
+- _TypeScript_;
+- _Docker_.
 
 E para a **consistência de estilo e qualidade de código**:
 
@@ -23,6 +24,22 @@ E para a **consistência de estilo e qualidade de código**:
 - _Commitlint_;
 - _Lint Staged_;
 - _Simple Import Sort_.
+
+### Em relação a containers Docker
+
+Além disso, "_dockerizei_" a aplicação para ter um ambiente de desenvolvimento utilizando o próprio servidor do Astro e um ambiente de produção com Nginx, ambos facilmente acessíveis à partir de suas imagens orquestradas pelo `docker compose`. Acesse-os com os seguintes comandos em seu terminal:
+
+```bash
+# Ambiente de desenvolvimento:
+docker compose up --build
+
+#Ambiente de produção:
+docker compose -f docker-compose.prod.yaml --build
+```
+
+> `--build` só é necessário caso você queria realmente "_buildar_" as imagens da aplicação.
+
+Dessa forma você terá acesso na porta 3000 do seu computador à aplicação, em ambos os ambientes. Só será necessário, após subir o container de sua preferência, acessar: http://localhost:3000/.
 
 ## Licença
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,7 +13,8 @@ Hello! I'm **Edson Pimenta**, a **full-stack developer** constantly evolving, **
 Focusing on the **delivery of useful and performant content**, I chose the following technologies:
 
 - _Astro_;
-- _TypeScript_.
+- _TypeScript_;
+- _Docker_.
 
 And for **style consistency and code quality**:
 
@@ -23,6 +24,22 @@ And for **style consistency and code quality**:
 - _Commitlint_;
 - _Lint Staged_;
 - _Simple Import Sort_.
+
+### About Docker containers
+
+Besides all that, I've "dockerized" the application for both development and production environments, using the Astro server for the development env and Nginx for production. Both are orchestrated by `docker compose`, access them easily with the following commands on your terminal:
+
+```bash
+# Development environment:
+docker compose up --build
+
+# Production environment:
+docker compose -f docker-compose.prod.yaml --build
+```
+
+> `--build` on those commands are only necessary if you want to actually build the application image.
+
+Just by doing that you'll be able to access through port 3000 of your computer the application, both the envs are being served through the same port. It will be necessary, after running the selected container, access: http://localhost:3000/.
 
 ## License
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,11 @@
+name: eddyyxxyyprod
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    container_name: portfolio-prod
+    image: eddyyxxyy/portfolio-prod:v1
+    ports:
+      - 3000:8080

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes  1;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  server {
+    listen 8080;
+    server_name   _;
+
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    include /etc/nginx/mime.types;
+
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    error_page 404 /404.html;
+    location = /404.html {
+            root /usr/share/nginx/html;
+            internal;
+    }
+
+    location / {
+            try_files $uri $uri/index.html =404;
+    }
+  }
+}


### PR DESCRIPTION
## Description

"Dockerizes" application for an isolated prod environment with Nginx and also updates both `README*.md` files to contain instructions of how to use Docker to initialize the application in both envs.

## Checklist

- [x] Create both Dockerfile and docker-compose.yaml to isolate prod environment with Nginx.
- [x] Update both `README*.md` files to contain instruction on how to initialize the application with Docker.