### PR TITLE
refactor(component): :lipstick: adds border and drop-shadow to  component

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -71,6 +71,8 @@ const translationObject = translationsFooter[currentLang];
   footer {
     padding: 2.4rem 2rem;
     text-align: center;
+    border-top: 1px solid var(--neutral-100);
+    box-shadow: rgba(0, 0, 0, 0.15) 3px 0px 3px 3px;
   }
 
   #socials {


### PR DESCRIPTION
## Description

Footer was lacking a delimiter to separate it from the main content of all pages.

## Checklist

- [x] Add the border and drop shadow to `Footer` component.