### PR TITLE
fix(seo): :adhesive_bandage: adds `aria-label`s to all `LinkButton`s and removes unused vars in `Footer`

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,6 @@ import { translationsFooter } from "@i18n/Footer";
 
 const { appVersion } = Astro.locals;
 
-const currentPathname = Astro.url.pathname.replace("/pt-br", "");
 const currentLang = Astro.currentLocale === "en" ? "en" : "pt-br";
 
 const translationObject = translationsFooter[currentLang];
@@ -20,6 +19,7 @@ const translationObject = translationsFooter[currentLang];
           href="https://github.com/eddyyxxyy"
           target="_blank"
           rel="noreferer"
+          aria-label={translationObject.githubLinkAriaLabel}
           title="Github"
         >
           <Icon name="github-logo" size={32} />
@@ -30,6 +30,7 @@ const translationObject = translationsFooter[currentLang];
           href="https://www.linkedin.com/in/eeddyyxxyy/"
           target="_blank"
           rel="noreferer"
+          aria-label={translationObject.linkedinLinkAriaLabel}
           title="LinkedIn"
         >
           <Icon name="linkedin-logo" size={32} />
@@ -40,6 +41,7 @@ const translationObject = translationsFooter[currentLang];
           href="https://www.youtube.com/@eddyxide"
           target="_blank"
           rel="noreferer"
+          aria-label={translationObject.youtubeChannelLinkAriaLabel}
           title="Youtube"
         >
           <Icon name="youtube-logo" size={32} />
@@ -48,6 +50,7 @@ const translationObject = translationsFooter[currentLang];
       <li>
         <a
           href={translationObject.resumeHref}
+          aria-label={translationObject.resumeLink}
           title={translationObject.resumeLink}
           download
         >

--- a/src/i18n/Footer.ts
+++ b/src/i18n/Footer.ts
@@ -4,12 +4,18 @@ const translationsFooter = {
     resumeHref: "/Edson_Pimenta_resume.pdf",
     resumeLink: "Download resume",
     repositoryLink: "Project repository",
+    githubLinkAriaLabel: "Edson's Github profile page",
+    linkedinLinkAriaLabel: "Edson's LinkedIn profile page",
+    youtubeChannelLinkAriaLabel: "Edson's Youtube channel",
   },
   "pt-br": {
     h1: "Conecte-se comigo",
     resumeHref: "/Edson_Pimenta_curriculo.pdf",
     resumeLink: "Baixar currículo",
     repositoryLink: "Repositório do projeto",
+    githubLinkAriaLabel: "Perfil do Github do Edson",
+    linkedinLinkAriaLabel: "Perfil do LinkedIn do Edson",
+    youtubeChannelLinkAriaLabel: "Canal no Youtube do Edson",
   },
 };
 


### PR DESCRIPTION
## Description

Removes `currentPath` var that was supposed to be used as a way of providing the right links to a `navbar` that didn't ended up in the `Footer` component code.

Also, it adds `aria-label`s in all links for accessibility reasons.

## Checklist

- [x] Remove unused vars from `Footer` component.
- [x] Add `aria-label`s to all links in `Footer` component.