### PR TITLE
fix(docs): :memo: fixes prod env docker compose up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Além disso, "_dockerizei_" a aplicação para ter um ambiente de desenvolviment
 # Ambiente de desenvolvimento:
 docker compose up --build
 
-#Ambiente de produção:
-docker compose -f docker-compose.prod.yaml --build
+# Ambiente de produção:
+docker compose -f docker-compose.prod.yaml up --build
 ```
 
 > `--build` só é necessário caso você queira realmente "_buildar_" as imagens da aplicação.

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,7 +34,7 @@ Besides all that, I've "dockerized" the application for both development and pro
 docker compose up --build
 
 # Production environment:
-docker compose -f docker-compose.prod.yaml --build
+docker compose -f docker-compose.prod.yaml up --build
 ```
 
 > `--build` on those commands are only necessary if you want to actually build the application image.


### PR DESCRIPTION
## Description

Fixes `docker compose -f docker-compose.prod.yaml --build` by adding `up` before `--build` arg.

## Checklist

- [x] Add the missing `up` in docker compose command on docs.